### PR TITLE
Bug when writing non-binary (XML) plist with Data values

### DIFF
--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -31,6 +31,19 @@ class TestWritePlist(unittest.TestCase):
     
     def testXMLPlist(self):
         self.roundTrip({'hello':'world'}, xml=True)
+
+    def testXMLPlistWithData(self):
+        for binmode in (True, False):
+            binplist = writePlistToString({'data': Data('\x01\xac\xf0\xff')}, binary=binmode)
+            plist = readPlistFromString(binplist)
+            self.assertTrue(isinstance(plist['data'], Data), \
+                "unable to encode then decode Data into %s plist" % ("binary" if binmode else "XML"))
+
+    def testConvertToXMLPlistWithData(self):
+        binplist = writePlistToString({'data': Data('\x01\xac\xf0\xff')})
+        plist = readPlistFromString(binplist)
+        xmlplist = writePlistToString(plist, binary=False)
+        self.assertTrue(len(xmlplist) > 0, "unable to convert plist with Data from binary to XML")
     
     def testBoolRoot(self):
         self.roundTrip(True)


### PR DESCRIPTION
If biplist is used to convert a binary plist into an XML one, like so:

```
plist = readPlist(..binary plist..)
writePlist(plist, file, binary=False)
```

and the binary plist happens to contain a `Data` value, this value would not be correctly represented in its XML form. In some cases, plistlib would raise a ValueError that says "_strings can't contains control characters; use plistlib.Data instead_".

This is because the `Data` class used by biplist is directly being passed to `plistlib`, but `plistlib` has its own `plistlib.Data` class to represent Data values.

This commit introduces a function `wrapDataObject` to convert to and from these different types during reading and writing of a non-binary plist. Test cases have also been added.
